### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server that provides real-time WallStreetBets data for analysis with Claude or other LLM clients.
 
+<a href="https://glama.ai/mcp/servers/@ferdousbhai/wsb-analyst-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ferdousbhai/wsb-analyst-mcp/badge" alt="WSB Analyst Server MCP server" />
+</a>
+
 ## Features
 
 - **Fetch WallStreetBets Posts**: Filter posts by score, comment count, and content type


### PR DESCRIPTION
This PR adds a badge for the [WSB Analyst MCP Server](https://glama.ai/mcp/servers/@ferdousbhai/wsb-analyst-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ferdousbhai/wsb-analyst-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ferdousbhai/wsb-analyst-mcp/badge" alt="WSB Analyst Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.